### PR TITLE
Revert changes related to 1.21 upg

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,11 @@ module "aws_eks_addons" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| addon\_coredns\_version | Version for addon\_coredns\_version | `string` | `"v1.8.3-eksbuild.1"` | no |
+| addon\_coredns\_version | Version for addon\_coredns\_version | `string` | `"v1.8.4-eksbuild.1"` | no |
 | addon\_create\_coredns | Create coredns addon | `bool` | `true` | no |
 | addon\_create\_kube\_proxy | Create kube\_proxy addon | `bool` | `true` | no |
 | addon\_create\_vpc\_cni | Create vpc\_cni addon | `bool` | `true` | no |
-| addon\_kube\_proxy\_version | Version for addon\_kube\_proxy\_version | `string` | `"v1.20.7-eksbuild.1"` | no |
+| addon\_kube\_proxy\_version | Version for addon\_kube\_proxy\_version | `string` | `"v1.21.2-eksbuild.2"` | no |
 | addon\_tags | Cluster addon tags | `map(string)` | `{}` | no |
 | addon\_vpc\_cni\_version | Version for addon\_create\_vpc\_cni | `string` | `"v1.9.3-eksbuild.1"` | no |
 | cluster\_name | Kubernetes cluster name - used to name (id) the auth0 resources | `any` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -53,13 +53,13 @@ module "aws_eks_addons" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| addon\_coredns\_version | Version for addon\_coredns\_version | `string` | `"v1.8.4-eksbuild.1"` | no |
+| addon\_coredns\_version | Version for addon\_coredns\_version | `string` | `"v1.8.3-eksbuild.1"` | no |
 | addon\_create\_coredns | Create coredns addon | `bool` | `true` | no |
 | addon\_create\_kube\_proxy | Create kube\_proxy addon | `bool` | `true` | no |
 | addon\_create\_vpc\_cni | Create vpc\_cni addon | `bool` | `true` | no |
-| addon\_kube\_proxy\_version | Version for addon\_kube\_proxy\_version | `string` | `"v1.21.2-eksbuild.2"` | no |
+| addon\_kube\_proxy\_version | Version for addon\_kube\_proxy\_version | `string` | `"v1.20.7-eksbuild.1"` | no |
 | addon\_tags | Cluster addon tags | `map(string)` | `{}` | no |
-| addon\_vpc\_cni\_version | Version for addon\_create\_vpc\_cni | `string` | `"v1.10.2-eksbuild.1"` | no |
+| addon\_vpc\_cni\_version | Version for addon\_create\_vpc\_cni | `string` | `"v1.9.3-eksbuild.1"` | no |
 | cluster\_name | Kubernetes cluster name - used to name (id) the auth0 resources | `any` | n/a | yes |
 | cluster\_oidc\_issuer\_url | Used to create the IAM OIDC role | `string` | `""` | no |
 | eks\_cluster\_id | trigger for null resource using eks\_cluster\_id | `any` | n/a | yes |

--- a/variables.tf
+++ b/variables.tf
@@ -32,13 +32,13 @@ variable "addon_vpc_cni_version" {
 }
 
 variable "addon_kube_proxy_version" {
-  default     = "v1.20.7-eksbuild.1"
+  default     = "v1.21.2-eksbuild.2"
   description = "Version for addon_kube_proxy_version"
   type = string
 }
 
 variable "addon_coredns_version" {
-  default     = "v1.8.3-eksbuild.1"
+  default     = "v1.8.4-eksbuild.1"
   description = "Version for addon_coredns_version"
   type = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -26,19 +26,19 @@ variable "addon_create_coredns" {
 }
 
 variable "addon_vpc_cni_version" {
-  default     = "v1.10.2-eksbuild.1"
+  default     = "v1.9.3-eksbuild.1"
   description = "Version for addon_create_vpc_cni"
   type = string
 }
 
 variable "addon_kube_proxy_version" {
-  default     = "v1.21.2-eksbuild.2"
+  default     = "v1.20.7-eksbuild.1"
   description = "Version for addon_kube_proxy_version"
   type = string
 }
 
 variable "addon_coredns_version" {
-  default     = "v1.8.4-eksbuild.1"
+  default     = "v1.8.3-eksbuild.1"
   description = "Version for addon_coredns_version"
   type = string
 }


### PR DESCRIPTION
CoreDNS
https://docs.aws.amazon.com/eks/latest/userguide/managing-coredns.html

Kube-proxy
https://docs.aws.amazon.com/eks/latest/userguide/managing-kube-proxy.html

We can upgrade cni when this issue is resolved:
https://github.com/aws/amazon-vpc-cni-k8s/issues/1930