### PR TITLE
Changing resolve_conflict_on_update > OVERWRITE

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -104,7 +104,7 @@ resource "aws_eks_addon" "coredns" {
   cluster_name      = var.eks_cluster_id
   addon_name        = "coredns"
   resolve_conflicts_on_create = "OVERWRITE"
-  resolve_conflicts_on_update = "PRESERVE"
+  resolve_conflicts_on_update = "OVERWRITE"
   addon_version     = var.addon_coredns_version
 
   tags = var.addon_tags


### PR DESCRIPTION
This PR sets resolve_conflicts_on_update to OVERWRITE to mitigate issue of the failing readiness endpoint port number

Previously we had this set to PRESERVE which failed to update coredns readiness port number from 8080 to 8181.

https://docs.aws.amazon.com/eks/latest/userguide/managing-coredns.html

https://github.com/aws/containers-roadmap/issues/941

