### PR TITLE
chore: 🤖 bump coredns v1.9.3-eksbuild.11

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -28,19 +28,19 @@ variable "addon_create_coredns" {
 variable "addon_vpc_cni_version" {
   default     = "v1.16.0-eksbuild.1"
   description = "Version for addon_create_vpc_cni"
-  type = string
+  type        = string
 }
 
 variable "addon_kube_proxy_version" {
   default     = "v1.25.16-eksbuild.1"
   description = "Version for addon_kube_proxy_version"
-  type = string
+  type        = string
 }
 
 variable "addon_coredns_version" {
-  default     = "v1.9.3-eksbuild.10"
+  default     = "v1.9.3-eksbuild.11"
   description = "Version for addon_coredns_version"
-  type = string
+  type        = string
 }
 
 variable "cluster_oidc_issuer_url" {


### PR DESCRIPTION
`TopologySpreadConstraints` have been added in this coredns release.

[Topology Spread Constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) control how pods are spread across your cluster among failure-domains such as regions, zones, nodes, and other user-defined topology domains. This can help to achieve high availability as well as efficient resource utilization.

It makes sense to have a coredns pod available in each zone to increase reliability and decrease latency.

Topology Spread Constraint fields explained:

- `labelSelector` is used to find matching Pods
- `maxSkew` describes the maximum degree to which Pods can be unevenly distributed
- `topologyKey` is the key that defines a topology in the Nodes' labels
- `whenUnsatisfiable` specifies, when "maxSkew" can't be satisfied, what action
- ` ScheduleAnyway` tells the scheduler to still schedule it while prioritizing Nodes that reduce the skew. It's a soft constraint

[here for more details](https://kubernetes.io/blog/2020/05/introducing-podtopologyspread/)

```
---------------------------------------------------------------------------------------------------------
      coredns-5488646b8d-qkjxn-before.yaml                              |       coredns-6767b497f8-6hnrs-after.yaml
---------------------------------------------------------------------------------------------------------
---------------------------------------------------------------------------------------------------------

  creationTimestamp: "2024-02-05T10:32:59Z"                   |   creationTimestamp: "2024-02-05T11:51:11Z"
  generateName: coredns-5488646b8d-                           |   generateName: coredns-6767b497f8-
    pod-template-hash: 5488646b8d                             |     pod-template-hash: 6767b497f8
  name: coredns-5488646b8d-qkjxn                              |   name: coredns-6767b497f8-6hnrs
    name: coredns-5488646b8d                                  |     name: coredns-6767b497f8
    uid: a24eed83-1b89-4de4-8228-e2b796f26456                 |     uid: e811d044-82bc-405b-851f-6aa47dcb4728
  resourceVersion: "1205"                                     |   resourceVersion: "40060"
  uid: 3dbe44bd-8f11-4daa-8c37-6d1bdd9c5cf3                   |   uid: 48a174cd-5820-4f48-8787-4b9dc987308c
    image: 602401143452.dkr.ecr.eu-west-2.amazonaws.com/eks/c |     image: 602401143452.dkr.ecr.eu-west-2.amazonaws.com/eks/c
      name: kube-api-access-8wddr                             |       name: kube-api-access-mf9mh
  nodeName: ip-172-20-92-45.eu-west-2.compute.internal        |   nodeName: ip-172-20-121-64.eu-west-2.compute.internal
                                                              >   topologySpreadConstraints:
                                                              >   - labelSelector:
                                                              >       matchLabels:
                                                              >         k8s-app: kube-dns
                                                              >     maxSkew: 1
                                                              >     topologyKey: topology.kubernetes.io/zone
                                                              >     whenUnsatisfiable: ScheduleAnyway
  - name: kube-api-access-8wddr                               |   - name: kube-api-access-mf9mh
    lastTransitionTime: "2024-02-05T10:34:21Z"                |     lastTransitionTime: "2024-02-05T11:51:11Z"
    lastTransitionTime: "2024-02-05T10:34:25Z"                |     lastTransitionTime: "2024-02-05T11:51:14Z"
    lastTransitionTime: "2024-02-05T10:34:25Z"                |     lastTransitionTime: "2024-02-05T11:51:14Z"
    lastTransitionTime: "2024-02-05T10:34:21Z"                |     lastTransitionTime: "2024-02-05T11:51:11Z"
  - containerID: containerd://569baf0ac3e7ea0ea14f6e9ae598dba |   - containerID: containerd://59275c94391a975282987ce34a4bc35
    image: 602401143452.dkr.ecr.eu-west-2.amazonaws.com/eks/c |     image: 602401143452.dkr.ecr.eu-west-2.amazonaws.com/eks/c
    imageID: 602401143452.dkr.ecr.eu-west-2.amazonaws.com/eks |     imageID: 602401143452.dkr.ecr.eu-west-2.amazonaws.com/eks
        startedAt: "2024-02-05T10:34:24Z"                     |         startedAt: "2024-02-05T11:51:12Z"
  hostIP: 172.20.92.45                                        |   hostIP: 172.20.121.64
  podIP: 172.20.76.80                                         |   podIP: 172.20.112.18
  - ip: 172.20.76.80                                          |   - ip: 172.20.112.18
  startTime: "2024-02-05T10:34:21Z"                           |   startTime: "2024-02-05T11:51:11Z"
---------------------------------------------------------------------------------------------------------
```