### PR TITLE
chore: 🤖 bump kube-proxy to v1.26.12-eksbuild.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ module "aws_eks_addons" {
 | <a name="input_addon_create_coredns"></a> [addon\_create\_coredns](#input\_addon\_create\_coredns) | Create coredns addon | `bool` | `true` | no |
 | <a name="input_addon_create_kube_proxy"></a> [addon\_create\_kube\_proxy](#input\_addon\_create\_kube\_proxy) | Create kube\_proxy addon | `bool` | `true` | no |
 | <a name="input_addon_create_vpc_cni"></a> [addon\_create\_vpc\_cni](#input\_addon\_create\_vpc\_cni) | Create vpc\_cni addon | `bool` | `true` | no |
-| <a name="input_addon_kube_proxy_version"></a> [addon\_kube\_proxy\_version](#input\_addon\_kube\_proxy\_version) | Version for addon\_kube\_proxy\_version | `string` | `"v1.25.16-eksbuild.1"` | no |
+| <a name="input_addon_kube_proxy_version"></a> [addon\_kube\_proxy\_version](#input\_addon\_kube\_proxy\_version) | Version for addon\_kube\_proxy\_version | `string` | `"v1.26.9-eksbuild.2"` | no |
 | <a name="input_addon_tags"></a> [addon\_tags](#input\_addon\_tags) | Cluster addon tags | `map(string)` | `{}` | no |
 | <a name="input_addon_vpc_cni_version"></a> [addon\_vpc\_cni\_version](#input\_addon\_vpc\_cni\_version) | Version for addon\_create\_vpc\_cni | `string` | `"v1.16.2-eksbuild.1"` | no |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Kubernetes cluster name - used to name (id) the auth0 resources | `any` | n/a | yes |

--- a/variables.tf
+++ b/variables.tf
@@ -32,7 +32,7 @@ variable "addon_vpc_cni_version" {
 }
 
 variable "addon_kube_proxy_version" {
-  default     = "v1.25.16-eksbuild.1"
+  default     = "v1.26.9-eksbuild.2"
   description = "Version for addon_kube_proxy_version"
   type        = string
 }


### PR DESCRIPTION
- Actually we are updating to an older version `v1.26.9-eksbuild.2` this is because the [aws ui](https://docs.aws.amazon.com/eks/latest/userguide/managing-kube-proxy.html) suggests a kube proxy version that doesn't actually exist

