### PR TITLE
Update coredns local exec command

### DIFF
--- a/coredns.tf
+++ b/coredns.tf
@@ -34,7 +34,7 @@ resource "null_resource" "more_coredns_pods" {
   provisioner "local-exec" {
     command = <<-EOT
       aws eks --region eu-west-2 update-kubeconfig --name ${var.cluster_name}
-      count=$(kubectl get nodes | grep Ready | wc -l) ; let count/=5 ; [ $count -lt 3 ] && count=3
+      count=$(kubectl get nodes | grep Ready | wc -l) ; count=$((count / 5)) ; [ $count -lt 3 ] && count=3
       kubectl -n kube-system scale deployment coredns --replicas=$count
     EOT
   }


### PR DESCRIPTION
In the existing local exec script, we use `let count/=5` to calculate the replica number for coredns.
However, Concourse does not have `let` in `/bin/sh` - [Concourse log](https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/create-cluster/jobs/create/builds/215#L65fda972:2919)
```
module.aws_eks_addons.null_resource.more_coredns_pods (local-exec): /bin/sh: 2: let: not found
```

Update the script to fix it.