### PR TITLE
Upgrade vpc cni 1.28

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ module "aws_eks_addons" {
 | <a name="input_addon_create_vpc_cni"></a> [addon\_create\_vpc\_cni](#input\_addon\_create\_vpc\_cni) | Create vpc\_cni addon | `bool` | `true` | no |
 | <a name="input_addon_kube_proxy_version"></a> [addon\_kube\_proxy\_version](#input\_addon\_kube\_proxy\_version) | Version for addon\_kube\_proxy\_version | `string` | `"v1.27.10-eksbuild.2"` | no |
 | <a name="input_addon_tags"></a> [addon\_tags](#input\_addon\_tags) | Cluster addon tags | `map(string)` | `{}` | no |
-| <a name="input_addon_vpc_cni_version"></a> [addon\_vpc\_cni\_version](#input\_addon\_vpc\_cni\_version) | Version for addon\_create\_vpc\_cni | `string` | `"v1.17.1-eksbuild.1"` | no |
+| <a name="input_addon_vpc_cni_version"></a> [addon\_vpc\_cni\_version](#input\_addon\_vpc\_cni\_version) | Version for addon\_create\_vpc\_cni | `string` | `"v1.18.1-eksbuild.3"` | no |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Kubernetes cluster name - used to name (id) the auth0 resources | `any` | n/a | yes |
 | <a name="input_cluster_oidc_issuer_url"></a> [cluster\_oidc\_issuer\_url](#input\_cluster\_oidc\_issuer\_url) | Used to create the IAM OIDC role | `string` | `""` | no |
 | <a name="input_eks_cluster_id"></a> [eks\_cluster\_id](#input\_eks\_cluster\_id) | trigger for null resource using eks\_cluster\_id | `any` | n/a | yes |

--- a/variables.tf
+++ b/variables.tf
@@ -26,7 +26,7 @@ variable "addon_create_coredns" {
 }
 
 variable "addon_vpc_cni_version" {
-  default     = "v1.17.1-eksbuild.1"
+  default     = "v1.18.1-eksbuild.3"
   description = "Version for addon_create_vpc_cni"
   type        = string
 }

--- a/vpc-cni.tf
+++ b/vpc-cni.tf
@@ -58,6 +58,7 @@ resource "aws_eks_addon" "vpc_cni" {
       # Configure cni daemonset to support higher pod density https://docs.aws.amazon.com/eks/latest/userguide/cni-increase-ip-addresses.html
       ENABLE_PREFIX_DELEGATION = "true"
       WARM_PREFIX_TARGET       = "1"
+      ENABLE_SUBNET_DISCOVERY  = "false" # https://github.com/aws/amazon-vpc-cni-k8s/blob/8f9253e2e4452fe0e9e6a26a05675c8b7ae7a8fe/README.md?plain=1#L548
     }
   })
 


### PR DESCRIPTION
Tests:

- addon successfully upgrades ✅ 
- Int tests are passing ✅ 
- enis are being span up correctly and pods are getting ips assigned correctly (tested up to 5000 pods) ✅ 
- nothing unusual in aws-node logs ✅ 
- ipamd node logs checked on new nodes, ips are successfully assigned ✅ 
- cluster upgraded to 1.28 and pods scaled to 800 successfully (bringing up new nodes) ✅ 

```
Subnet discovery is enabled by default. VPC-CNI will pick the subnet with the most number of free IPs from the nodes' VPC/AZ to create the secondary ENIs. The subnets considered are the subnet the node is created in and subnets tagged with `kubernetes.io/role/cni`.
If `ENABLE_SUBNET_DISCOVERY` is set to `false` or if DescribeSubnets fails due to IAM permissions, all secondary ENIs will be created in the subnet the node is created in.
```

`ENABLE_SUBNET_DISCOVERY` --> We should set this to false to preserve our current behaviour. Even if this is set to true the behaviour should be the same as we don't use the `kubernetes.io/role/cni` tag on our subnets. Setting this to false protects us from future module changes which may bring in this tagging. 

https://github.com/aws/amazon-vpc-cni-k8s/blob/8f9253e2e4452fe0e9e6a26a05675c8b7ae7a8fe/README.md?plain=1#L548

```
---------------------------------------------------------------------------------------------------------
      aws-node-5d2wk-before.yaml                              |       aws-node-6k6jv-after.yaml
---------------------------------------------------------------------------------------------------------
---------------------------------------------------------------------------------------------------------

  creationTimestamp: "2024-06-06T08:36:42Z"                   |   annotations:
                                                              >     github_teams: all-org-members
                                                              >   creationTimestamp: "2024-06-06T11:04:44Z"
    controller-revision-hash: 956849f86                       |     controller-revision-hash: b6d79ffcf
    pod-template-generation: "2"                              |     pod-template-generation: "4"
  name: aws-node-5d2wk                                        |   name: aws-node-6k6jv
  resourceVersion: "1261"                                     |   resourceVersion: "60129"
  uid: 58be49eb-fcef-407e-8449-dda7239385a7                   |   uid: ad0192c8-7847-4805-a4e3-6bcf87331875
            - ip-172-20-100-78.eu-west-2.compute.internal     |             - ip-172-20-66-221.eu-west-2.compute.internal
    - name: CLUSTER_ENDPOINT                                  <
      value: https://128E90F5A4726655B0A3E60C704382FF.gr7.eu- <
                                                              >     - name: ENABLE_SUBNET_DISCOVERY
                                                              >       value: "false"
      value: v1.17.1                                          |       value: v1.18.1
    image: 602401143452.dkr.ecr.eu-west-2.amazonaws.com/amazo |     image: 602401143452.dkr.ecr.eu-west-2.amazonaws.com/amazo
      name: kube-api-access-skkxm                             |       name: kube-api-access-8pjn8
    image: 602401143452.dkr.ecr.eu-west-2.amazonaws.com/amazo |     image: 602401143452.dkr.ecr.eu-west-2.amazonaws.com/amazo
      name: kube-api-access-skkxm                             |       name: kube-api-access-8pjn8
    image: 602401143452.dkr.ecr.eu-west-2.amazonaws.com/amazo |     image: 602401143452.dkr.ecr.eu-west-2.amazonaws.com/amazo
      name: kube-api-access-skkxm                             |       name: kube-api-access-8pjn8
  nodeName: ip-172-20-100-78.eu-west-2.compute.internal       |   nodeName: ip-172-20-66-221.eu-west-2.compute.internal
  - name: kube-api-access-skkxm                               |   - name: kube-api-access-8pjn8
    lastTransitionTime: "2024-06-06T08:36:52Z"                |     lastTransitionTime: "2024-06-06T11:04:46Z"
    lastTransitionTime: "2024-06-06T08:36:55Z"                |     lastTransitionTime: "2024-06-06T11:04:48Z"
    lastTransitionTime: "2024-06-06T08:36:55Z"                |     lastTransitionTime: "2024-06-06T11:04:48Z"
    lastTransitionTime: "2024-06-06T08:36:42Z"                |     lastTransitionTime: "2024-06-06T11:04:44Z"
  - containerID: containerd://f42de97d4400152829d1c18252bcf35 |   - containerID: containerd://38bf0bc4d35383055d9be7e24494f62
    image: 602401143452.dkr.ecr.eu-west-2.amazonaws.com/amazo |     image: 602401143452.dkr.ecr.eu-west-2.amazonaws.com/amazo
    imageID: 602401143452.dkr.ecr.eu-west-2.amazonaws.com/ama |     imageID: 602401143452.dkr.ecr.eu-west-2.amazonaws.com/ama
        startedAt: "2024-06-06T08:36:55Z"                     |         startedAt: "2024-06-06T11:04:46Z"
  - containerID: containerd://74f46d6b455631eece98a676775695b |   - containerID: containerd://5890d26e56a03e087400b3f6304cf0c
    image: 602401143452.dkr.ecr.eu-west-2.amazonaws.com/amazo |     image: 066635153087.dkr.ecr.il-central-1.amazonaws.com/am
    imageID: 602401143452.dkr.ecr.eu-west-2.amazonaws.com/ama |     imageID: sha256:86800e25303d102ce2d081833ccb7b51b354d610f
        startedAt: "2024-06-06T08:36:54Z"                     |         startedAt: "2024-06-06T11:04:46Z"
  hostIP: 172.20.100.78                                       |   hostIP: 172.20.66.221
  - containerID: containerd://ab6f04b3b77788583f7233a5f8aeb43 |   - containerID: containerd://6a2e93eec3af91af2094197de59f205
    image: 602401143452.dkr.ecr.eu-west-2.amazonaws.com/amazo |     image: 066635153087.dkr.ecr.il-central-1.amazonaws.com/am
    imageID: 602401143452.dkr.ecr.eu-west-2.amazonaws.com/ama |     imageID: sha256:3f0789d4b13f6149abed0acb024fc383f0569f98e
        containerID: containerd://ab6f04b3b77788583f7233a5f8a |         containerID: containerd://6a2e93eec3af91af2094197de59
        finishedAt: "2024-06-06T08:36:47Z"                    |         finishedAt: "2024-06-06T11:04:45Z"
        startedAt: "2024-06-06T08:36:47Z"                     |         startedAt: "2024-06-06T11:04:45Z"
  podIP: 172.20.100.78                                        |   podIP: 172.20.66.221
  - ip: 172.20.100.78                                         |   - ip: 172.20.66.221
  startTime: "2024-06-06T08:36:42Z"                           |   startTime: "2024-06-06T11:04:44Z"
---------------------------------------------------------------------------------------------------------

```

Additional reading:

https://aws.amazon.com/blogs/containers/amazon-vpc-cni-introduces-enhanced-subnet-discovery/