### PR TITLE
chore: 🤖 bump vpc-cni to latest version for eks 1.28

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ module "aws_eks_addons" {
 | <a name="input_addon_create_vpc_cni"></a> [addon\_create\_vpc\_cni](#input\_addon\_create\_vpc\_cni) | Create vpc\_cni addon | `bool` | `true` | no |
 | <a name="input_addon_kube_proxy_version"></a> [addon\_kube\_proxy\_version](#input\_addon\_kube\_proxy\_version) | Version for addon\_kube\_proxy\_version | `string` | `"v1.27.10-eksbuild.2"` | no |
 | <a name="input_addon_tags"></a> [addon\_tags](#input\_addon\_tags) | Cluster addon tags | `map(string)` | `{}` | no |
-| <a name="input_addon_vpc_cni_version"></a> [addon\_vpc\_cni\_version](#input\_addon\_vpc\_cni\_version) | Version for addon\_create\_vpc\_cni | `string` | `"v1.18.1-eksbuild.3"` | no |
+| <a name="input_addon_vpc_cni_version"></a> [addon\_vpc\_cni\_version](#input\_addon\_vpc\_cni\_version) | Version for addon\_create\_vpc\_cni | `string` | `"v1.18.2-eksbuild.1"` | no |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Kubernetes cluster name - used to name (id) the auth0 resources | `any` | n/a | yes |
 | <a name="input_cluster_oidc_issuer_url"></a> [cluster\_oidc\_issuer\_url](#input\_cluster\_oidc\_issuer\_url) | Used to create the IAM OIDC role | `string` | `""` | no |
 | <a name="input_eks_cluster_id"></a> [eks\_cluster\_id](#input\_eks\_cluster\_id) | trigger for null resource using eks\_cluster\_id | `any` | n/a | yes |

--- a/variables.tf
+++ b/variables.tf
@@ -26,7 +26,7 @@ variable "addon_create_coredns" {
 }
 
 variable "addon_vpc_cni_version" {
-  default     = "v1.18.1-eksbuild.3"
+  default     = "v1.18.2-eksbuild.1"
   description = "Version for addon_create_vpc_cni"
   type        = string
 }


### PR DESCRIPTION
relates to ministryofjustice/cloud-platform#5577

Checks

- [x] [release notes](https://github.com/aws/amazon-vpc-cni-k8s/releases/tag/v1.18.2)
- [x] bump release in test cluster
- [x] compare before after daemonset / pod configs
- [x] int tests passing
- [x] check ipamd logs for any errors/warnings